### PR TITLE
Frontend should back off when requests are pending

### DIFF
--- a/client/necsus.js
+++ b/client/necsus.js
@@ -226,10 +226,10 @@ let app = new Vue({
     },
     autoUpdate: function() {
       let vm = this;
-      if (vm.autoUpdater) window.clearInterval();
-      vm.autoUpdater = window.setInterval(function() {
-        vm.fetchMessages();
-      }, 1500);
+
+      vm.fetchMessages().finally(function() {
+        window.setTimeout(() => vm.autoUpdate(), 2000)
+      });
     },
     speak: function(text) {
       if (this.settings.speech) {


### PR DESCRIPTION
This slows polling down to once every 2 seconds rather than 1.5 seconds, and should (?? difficult to test) make the frontend back off when necsus is overloaded and polls are running long. Current behaviour is that further polls happen even when previous polls are pending.