### PR TITLE
bots: add timeouts to triggers

### DIFF
--- a/bots.py
+++ b/bots.py
@@ -72,5 +72,5 @@ def run(room, bot, text, params, user=None, state=None):
       return {
         'room': room,
         'author': 'necsus',
-        'text': f'Something went wrong. There was a {reply.status_code} error',
+        'text': f'Something went wrong. Bot {name!r} responded with a {reply.status_code} error',
       }

--- a/bots.py
+++ b/bots.py
@@ -41,7 +41,7 @@ def run(room, bot, text, params, user=None, state=None):
       if 'state' in message and message['state'] != None:
         safe_message['state'] = message['state']
         safe_message['reply_to'] = bot.get('id')
-      
+
       if 'image' in message and isinstance(message['image'], str):
         safe_message['image'] = message['image']
 

--- a/client/index.html
+++ b/client/index.html
@@ -99,7 +99,7 @@
         </div>
 
         <div id="new-message">
-          <textarea id="message-input" v-model="newMessage" v-bind="{placeholder: 'Message '+ room}" 
+          <textarea id="message-input" v-model="newMessage" v-bind="{placeholder: 'Message '+ room}"
             autofocus
             v-bind:rows="rows()" v-bind:disabled="sendingMessage"
             @keydown.enter.exact.prevent v-on:keyup.enter.exact="submitMessage(newMessage)"></textarea>

--- a/client/necsus.js
+++ b/client/necsus.js
@@ -26,7 +26,7 @@ let app = new Vue({
     vm.room = window.location.pathname.slice(1);
 
     /*
-      Fetch the room's messages and settings 
+      Fetch the room's messages and settings
     */
     vm.fetchBots();
     vm.fetchMessages({silent: true});
@@ -212,9 +212,9 @@ let app = new Vue({
     clearState: async function() {
       let data = new FormData();
       data.append('room', this.room);
-      
+
       this.sendingMessage = true;
-      
+
       let url = '/api/actions/clear-room-state'
       let response = await fetch(url, {
         method: 'POST',

--- a/crossdomain.py
+++ b/crossdomain.py
@@ -1,8 +1,8 @@
-from datetime import timedelta  
-from flask import Flask, make_response, request, current_app  
+from datetime import timedelta
+from flask import Flask, make_response, request, current_app
 from functools import update_wrapper
 
-def crossdomain(origin=None, methods=None, headers=None, max_age=21600, attach_to_all=True, automatic_options=True):  
+def crossdomain(origin=None, methods=None, headers=None, max_age=21600, attach_to_all=True, automatic_options=True):
     if methods is not None:
         methods = ', '.join(sorted(x.upper() for x in methods))
     if headers is not None and not isinstance(headers, str):

--- a/db.py
+++ b/db.py
@@ -111,16 +111,16 @@ class Messages(DBList):
     "Return a generator of messages since a given id (which may be None to return all messages)"
 
     messages = self.find_all(**kwargs)
-    
+
     take_from = 0 if since_id == None else int(since_id)
     newer_messages = (message for message in messages if int(message['id']) >= take_from)
-    
+
     for message in newer_messages:
       if message['state'] is not None:
         message['state'] = json.loads(message['state'])
-      
+
       yield message
-  
+
 
   def add(self, **message):
     now = UTC.localize(datetime.datetime.utcnow())
@@ -140,16 +140,16 @@ class Messages(DBList):
 
   def room_state(self, room_name):
     "Return None if the room has no special state, otherwise (bot_id, state)"
-    
+
     room_messages = self.find_all(room=room_name)
     if room_messages == []:
       return None
-    
+
     last_message = room_messages[-1]
     if last_message['reply_to'] != None:
       state = json.loads(last_message.get('state', None))
       return last_message['reply_to'], state
-    
+
     return None
 
 

--- a/events.py
+++ b/events.py
@@ -12,12 +12,12 @@ def trigger_message_post(db, message):
     bots = db.bots.find_all(id=bot_id)
     if len(bots) != 1:
       return message_result
-    
+
     bot = bots[0]
     trigger_bot(db, message, bot, {}, state=state, user=message.get('author', ''))
   else:
     trigger_bots(db, message)
-  
+
   return message_result
 
 
@@ -60,7 +60,7 @@ def trigger_bots(db, message):
       reply = trigger_bot(db, message, bot, match.groupdict(), user)
       replies.append(reply)
 
-  return replies 
+  return replies
 
 def trigger_bot(db, message, bot, params, user=None, state=None):
   text = message.get('text')
@@ -74,7 +74,7 @@ def trigger_bot(db, message, bot, params, user=None, state=None):
 def trigger_interaction(db, interaction):
   reply_message = interactivity.interact(interaction)
   reply_message_result = db.messages.add(**reply_message)
-  return reply_message 
+  return reply_message
 
 def trigger_room_reset(db, room):
   db.messages.delete(room=room)

--- a/events.py
+++ b/events.py
@@ -52,7 +52,7 @@ def trigger_bots(db, message):
       db.messages.add(
         room=room,
         author='necsus',
-        text=f'A bot with name {name!r} in this room has this invalid {t} regex: <pre>{search}</pre>'
+        text=f'Something went wrong. Bot {name!r} has an invalid {t} regex: <pre>{search}</pre>'
       )
       continue
 

--- a/interactivity.py
+++ b/interactivity.py
@@ -7,7 +7,7 @@ def interact(params):
   reply = requests.post(endpoint_url, params=params)
 
   if reply.status_code == requests.codes.ok:
-    return reply.json() 
+    return reply.json()
   else:
     return {
       'author': 'necsus',

--- a/necsus.ini
+++ b/necsus.ini
@@ -1,0 +1,16 @@
+[uwsgi]
+# Basic configuration.
+module = server:app
+logto = /var/log/necsus/%n.log
+vacuum = true
+die-on-term = true
+
+# Run in multi-worker mode.
+master = true
+processes = 12
+
+# uWSGI socket for nginx.
+socket = /var/run/necsus.sock
+chmod-socket = 660
+uid = www-data
+gid = www-data


### PR DESCRIPTION
Add a timeout (13 seconds for now -- 3 for connection, 10 for reading) to all 
bot requests.Student bots may never return (or may have gone down) and blocking 
request threads for a very long time doesn't end well.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>