### PR TITLE
Chatroom Documentation links open in new tab

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -174,8 +174,8 @@
             <div class="card-content">
               <span class="card-title">Documentation</span>
               <div class="collection">
-                <a class="collection-item" href="/docs">NeCSuS API docs</a>
-                <a class="collection-item" href="/bot/docs">Bot API docs</a>
+                <a class="collection-item" target="_blank" href="/docs">NeCSuS API docs</a>
+                <a class="collection-item" target="_blank" href="/bot/docs">Bot API docs</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Small UX change, documentation links while in a chatroom settings should open in a new tab.