### PR TITLE
Document and automate deployment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,40 @@ Documentation on the API can be found on [the main NeCSuS server](https://chat.n
 
 ## Development
 
-Run `python server.py` for the development server. This also inits the db if it
+Run `python3 server.py` for the development server. This also inits the db if it
 isn't already.
 
-Gunicorn is used for the production server (see the `Procfile`). `python
-server.py` must still be run at least once beforehand to init the db.
+## Deployment
 
+This server has been most recently deployed on a Digital Ocean droplet. Theoretically, this should be easily ported
+onto another VPS service on a different cloud provider such as AWS or Azure.
+
+Once you've SSH'd into the server, open a `tmux` session. This makes it easier to run multiple servers at once (i.e. gunicorn and caddy).
+
+Hint: If you need help with using tmux, use `Ctrl+b ?`.
+
+Run the following to install the necessary dependencies and start the server on localhost.
+
+```
+./install.sh && ./run.sh
+```
+
+Add the following to `/etc/caddy/Caddyfile` (remove/comment out the default config)
+
+```
+chat.ncss.cloud {
+	reverse_proxy localhost:6277
+	encode gzip
+}
+```
+
+Reload the caddy server to read the new config file.
+
+```
+systemctl reload caddy
+```
+
+The URL https://chat.ncss.cloud/ should now display a simple chat server!
 
 ## FAQ
 

--- a/init_db.py
+++ b/init_db.py
@@ -1,0 +1,3 @@
+from necsus import init_db
+
+init_db()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Install dependencies including caddy to reverse proxy
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+sudo apt update
+sudo apt install python3-pip python3-dev python3-cachecontrol python3-poetry caddy
+
+# Install dependencies
+poetry install

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+poetry run python3 init_db.py
+poetry run gunicorn --bind localhost:6277 server:app -w 1


### PR DESCRIPTION
The following commit aims to add a simple script for installing dependencies and running the server. The README has also been updated with instructions on how to do a deployment. This documentation is aimed at any new NCSS tutor who may need to set up the server again in the future.