### PR TITLE
Add special form support to NeCSuS

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -193,7 +193,7 @@ components:
           type: object
           nullable: true
           example: null
-        reply_to:
+        from_bot:
           type: integer
           example: 2
           nullable: true

--- a/client/index.html
+++ b/client/index.html
@@ -69,6 +69,7 @@
               :necsus-message-id="message.id"
               :class="messageClass(message)"
               v-for="message in displayMessages"
+              :key="message.id"
             >
               <div class="flex">
                 <b class="author flex-grow">{{ message.author }}</b>

--- a/client/necsus.js
+++ b/client/necsus.js
@@ -14,7 +14,7 @@ let app = new Vue({
       installedBots: [],
     },
     messages: [],
-    toEvalMessages: [],
+    toPostprocessMessages: [],
     modals: {},
     newMessage: '',
     newMessageHistory: [],      // For up-arrow back-going.
@@ -107,15 +107,26 @@ let app = new Vue({
     }.bind(this));
   },
   updated: function() {
-    let vm = this;
+    // We need to post-process messages, to redirect the forms, and eval the <script> tags.
+    // However, this updated() function is run every time the whole Vue component (the chatroom)
+    // updates, rather than when a message is inserted. So there might be a case where we have
+    // new messages to postprocess, but they have not reached the DOM yet. We need to be careful
+    // to only eval the ones that have reached the DOM.
+
+    // Find the messages to process that have reached the DOM on this update cycle.
+    let reachedDom = new Map()
+    for (let message of this.toPostprocessMessages) {
+      let domElt = document.querySelector(`div[necsus-message-id="${message.id}"]`)
+      if (domElt !== null)
+        reachedDom.set(message.id, {message, domElt})
+    }
 
     // First we are going to post-process the forms to attach our custom submit handlers,
     // for the form interactions with necsus.
-    for (let {id, from_bot} of vm.toEvalMessages) {
-      let domElt = document.querySelector(`div[necsus-message-id="${id}"]`)
+    for (let {message, domElt} of reachedDom.values()) {
       domElt.querySelectorAll('form').forEach((formElt) => {
         formElt.addEventListener('submit', (e) => this.formMessageSubmit(e))
-        formElt.dataset.from_bot = from_bot
+        formElt.dataset.from_bot = message.from_bot
       })
     }
 
@@ -126,48 +137,18 @@ let app = new Vue({
     // Unfortunately for us, XSS is a key feature of NeCSuS so we have to run
     // eval() on the <script> tags ourselves.
 
-    // Joel (2023-01-11): For some reason this sometimes throws an error on the necsus-message-id
-    // attribute, so I'm wrapping the whole thing in try-catch so that the form processing still works.
-
-    try {
-      // What is the mapping from (message-id) --> [<script>]?
-      let scriptMap = {};
-      Array.from(document.getElementsByClassName("message"))
-          .forEach(function(elem) {
-            let id = elem.attributes["necsus-message-id"].value;
-            scriptMap[id] = Array.from(elem.getElementsByTagName("script"));
-          });
-
-      // For each not-yet-eval()ed script, run it in the order received (noting
-      // that several script tags can exist in a message).
-      for (message of vm.toEvalMessages) {
-        let scripts = scriptMap[`${message.id}`];
-        if (scripts === undefined) {
-          continue;
-        }
-        scripts.forEach(function(elem, idx) {
-          // This is a fairly dodgy way of marking the script as "executed" so
-          // we don't run it twice. There is no disabled attribute (we could add
-          // a fake one but this makes sure the DOM doesn't render it by
-          // accident as well).
-          if (elem.type === "text/gzip") {
-            console.log(`Re-exec of existing <script>-${idx} in message ${message.id} skipped...`);
-            return;
-          }
-          elem.type = "text/gzip";
-
-          // TODO: Handle src=.
-          console.log(`Manually eval()ing message ${message.id} <script>-${idx} to get around Chrome XSS blocking...`);
-          window.eval(elem.innerHTML);
-        });
-      }
-    } catch (err) {
-      console.error('Error when processing scripts:', err)
+    // For each not-yet-eval()ed script, run it in the order received (noting
+    // that several script tags can exist in a message).
+    for (let {message, domElt} of reachedDom.values()) {
+      domElt.querySelectorAll('script').forEach((script) => {
+        console.log(`Manually eval()ing message ${message.id} to get around Chrome XSS blocking...`);
+        script.type = "text/gzip";
+        window.eval(script.innerHTML);
+      })
     }
 
-    // Clear to-eval messages. If there are any duplicates we won't double-exec
-    // them thanks to "text/gzip". It's more important we don't drop messages.
-    vm.toEvalMessages = [];
+    // Clear the messages we've processed.
+    this.toPostprocessMessages = this.toPostprocessMessages.filter(({id}) => !reachedDom.has(id));
   },
   methods: {
     formMessageSubmit: async function(e) {
@@ -289,7 +270,7 @@ let app = new Vue({
         });
       });
 
-      vm.toEvalMessages = newMessages;
+      vm.toPostprocessMessages = newMessages;
       vm.messages = vm.messages.concat(newMessages);
 
       // Check if the last message contains a state which we might have to clear
@@ -317,7 +298,7 @@ let app = new Vue({
         this.replyToBotName = message.author || '???';
       }
 
-      this.toEvalMessages.push(message)
+      this.toPostprocessMessages.push(message)
       this.messages.push(message)
     },
     createWebsocket: function() {

--- a/client/necsus.js
+++ b/client/necsus.js
@@ -51,6 +51,7 @@ let app = new Vue({
       Determine the room
     */
     vm.room = decodeURIComponent(window.location.pathname.slice(1));
+    document.title = `NeCSuS | ${vm.room}`
 
     // Updates (new messages, put/delete bots, clearing room, etc) all come over a websocket.
     vm.createWebsocket();
@@ -177,6 +178,7 @@ let app = new Vue({
         data[e.submitter.name] = e.submitter.value
 
       // Submit to our alternate endpoint via AJAX.
+      this.sendingMessage = true;
       await fetch('/api/actions/message-form', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -187,6 +189,7 @@ let app = new Vue({
           form_data: data,
         }),
       })
+      this.sendingMessage = false;
     },
     clearRoom: async function() {
       let response = await fetch('/api/actions/clear-room-messages', {

--- a/example_bots/server.py
+++ b/example_bots/server.py
@@ -85,5 +85,79 @@ def sleep():
   }
 
 
+@app.route('/form', methods=['POST'])
+def form():
+  """Example route for forms."""
+  return {
+    'author': 'FormBot',
+    'text': '''
+      <p>You have two options:</p>
+      <form method="POST" action="/form/handler">
+        <button name="mybutton" value="1">Option 1</button>, or
+        <button name="mybutton" value="2">Option 2</button>.
+      </form>
+      ''',
+  }
+
+@app.route('/form/handler', methods=['POST'])
+def form_handler():
+  # Expect an object of the form {room: string, form_data: object}.
+  data = request.get_json()
+  chosen = data['form_data']['mybutton']
+  return {
+    'author': 'FormBot',
+    'text': f"Option {chosen} is an excellent choice.",
+  }
+
+
+@app.route('/numberwang', methods=['POST'])
+def numberwang():
+  def form_html(mid):
+    return f"""
+      <form>
+        <p>Is your number
+          <button name="guess" value="lower">Lower</button>,
+          <button name="guess" value="correct">{mid}</button>, or
+          <button name="guess" value="higher">Higher</button>?
+      </form>
+    """
+
+  data = request.get_json()
+  if 'state' not in data:
+    lo, hi = 1, 100
+    mid = (lo + hi) // 2
+    return {
+      'author': 'Numberwang',
+      'text': f"<p>Pick a number between 1 and 100 and I will guess it! My first guess is {mid}.</p>{form_html(mid)}",
+      'state': [lo, hi],
+    }
+
+  if 'form_data' in data:
+    guess = data['form_data']['guess']
+  else:
+    guess = 'lower' if 'lower' in data['text'].lower() else 'higher' if 'higher' in data['text'].lower() else 'correct'
+
+  if guess == 'correct':
+    return {'author': 'Numberwang', 'text': "Woohoo, I win! Let's rotate the board!"}
+
+  print(data)
+  lo, hi = data.get('state', [1, 100])
+  mid = (lo + hi) // 2
+  if guess == 'lower':
+    hi = mid - 1
+  else:
+    lo = mid + 1
+
+  mid = (lo + hi) // 2
+  return {
+    'author': 'numberwang',
+    'text': form_html(mid),
+    'state': [lo, hi],
+  }
+
+
+
+
+
 if __name__ == '__main__':
   app.run(port=1234, debug=True)

--- a/necsus/db.py
+++ b/necsus/db.py
@@ -105,7 +105,7 @@ class DBList(dict):
 
 class Messages(DBList):
   table = Table('messages')
-  allowed_keys = ['id', 'room', 'author', 'kind', 'text', 'when', 'image', 'media', 'reply_to', 'state']
+  allowed_keys = ['id', 'room', 'author', 'kind', 'text', 'when', 'image', 'media', 'from_bot', 'state']
 
   def since(self, room: str, since_id: int = -1):
     """Return a list of all messages in the room with IDs strictly greater than a given ID, in ascending ID order."""
@@ -160,9 +160,9 @@ class Messages(DBList):
       return None
 
     last_message = room_messages[-1]
-    if last_message['reply_to'] != None:
+    if last_message['state'] != None:
       state = json.loads(last_message.get('state', None))
-      return last_message['reply_to'], state
+      return last_message['from_bot'], state
 
     return None
 

--- a/schema.sql
+++ b/schema.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS messages (
   "when" TEXT,
   image TEXT,
   media TEXT,
-  reply_to INTEGER,  -- If this message is last, forward responses to the bot with this id
+  from_bot INTEGER,  -- Non-null only if this message is from a bot.
   state BLOB         -- Only forward to the bot if this state is a nonempty string of json data.
 );
 


### PR DESCRIPTION
The necsus client now does something special on `<form>` elements, redirecting them to a JSON POST request to the necsus server, which will go and wake up the bot responsible for the form, and send it the form data. This means that buttons and other form inputs can be handled in a way much more similar to the usual bot workflow, instead of students having to inject javascript and then deal with a completely different workflow on the Flask side.

This addresses #72 rather nicely (and extends to other kinds of form inputs too).